### PR TITLE
Fix GPU execution for Dwarfs and minor API fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if(ENABLE_DPCPP)
       dpcpp_constant_cuda
       scan_cuda
       radix_cuda
+      omnisci_join_cuda
   )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if(ENABLE_DPCPP)
       scan_cuda
       radix_cuda
       omnisci_join_cuda
+      groupby_cuda
   )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,9 @@ if(ENABLE_DPCPP)
     groupby
     groupby_local
     hash_build_non_bitmask
+    omnisci_join
   )
+  
   if(ENABLE_EXPERIMENTAL)
     list(APPEND bench_libs
       reduce

--- a/README.md
+++ b/README.md
@@ -30,20 +30,37 @@
 #include <iostream>
 
 int main() {
-    DwarfBench::DwarfBench db;
+  std::vector<DwarfBench::DeviceType> devices = {
+    DwarfBench::DeviceType::CPU,
+    DwarfBench::DeviceType::GPU,
+  };
 
-    DwarfBench::RunConfig rc = {
-        .device = DwarfBench::DeviceType::CPU,
-        .inputSize = 1024,
-        .iterations = 10,
-        .dwarf = DwarfBench::Dwarf::TBBSort,
-    };
+  std::vector<DwarfBench::Dwarf> dwarfs = {
+    DwarfBench::Dwarf::Join,
+    DwarfBench::Dwarf::Sort,
+    DwarfBench::Dwarf::Scan,
+    DwarfBench::Dwarf::GroupBy
+  };
+  
+  DwarfBench::DwarfBench db;
 
-    auto results = db.makeMeasurements(rc);
+  for (DwarfBench::Dwarf dwarf: dwarfs) {
+    for (DwarfBench::DeviceType device: devices) {
+      DwarfBench::RunConfig rc = {
+          .device = device,
+          .inputSize = 1024,
+          .iterations = 10,
+          .dwarf = dwarf,
+      };
 
-    for (auto &result: results) {
-        std::cout << "RESULT: " << result.dataSize << ' ' << result.microseconds << std::endl;
+      auto results = db.makeMeasurements(rc);
+
+      for (auto &result : results) {
+        std::cout << dwarf << ' ' << device << " RESULT: " << result.dataSize << ' ' << result.microseconds
+                  << std::endl;
+      }
     }
+  }
 }
 ```
 

--- a/bench.cpp
+++ b/bench.cpp
@@ -9,39 +9,45 @@
 
 namespace DwarfBench {
 
-std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf) {
+std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf, DeviceType device) {
   switch (dwarf) {
   case ConstantExampleDPCPP: {
-    return "ConstantExampleDPCPP";
+    return device == DeviceType::CPU ? "ConstantExampleDPCPP" : "ConstantExampleDPCPPCuda";
   }
   case DPLScan: {
-    return "DPLScan";
+    return device == DeviceType::CPU ? "DPLScan" : "DPLScanCuda";
   }
   case GroupBy: {
-    return "GroupBy";
+    return device == DeviceType::CPU ? "GroupBy" : "GroupByCuda";
   }
   case GroupByLocal: {
+    assert(device != DeviceType::GPU && "Calling unsupported GroupByLocal for GPU execution dwarf");
     return "GroupByLocal";
   }
   case HashBuild: {
+    assert(device != DeviceType::GPU && "Calling unsupported HashBuild for GPU execution dwarf");
     return "HashBuild";
   }
   case HashBuildNonBitmask: {
+    assert(device != DeviceType::GPU && "Calling unsupported HashBuildNonBitmask for GPU execution dwarf");
     return "HashBuildNonBitmask";
   }
   case Join: {
+    assert(device != DeviceType::GPU && "Calling unsupported Join for GPU execution dwarf");
     return "Join";
   }
   case JoinOmnisci: {
-    return "JoinOmnisci";
+    return device == DeviceType::CPU ? "JoinOmnisci" : "JoinOmnisciCuda";
   }
   case NestedLoopJoin: {
+    assert(device != DeviceType::GPU && "Calling unsupported NestedLoopJoin for GPU execution dwarf");
     return "NestedLoopJoin";
   }
   case Radix: {
-    return "Radix";
+    return device == DeviceType::CPU ? "Radix" : "RadixCuda";
   }
   case TBBSort: {
+    assert(device != DeviceType::GPU && "Calling unsupported TBBSort for GPU execution dwarf");
     return "TBBSort";
   }
   default: {
@@ -65,7 +71,7 @@ std::vector<Measurement> DwarfBench::makeMeasurements(const RunConfig &conf) {
 
   GroupByRunOptions opts = GroupByRunOptions(_opts, 20, 1024); // TODO
 
-  std::string dwarfName = dwarfToString(dwarfToImpl(conf.dwarf));
+  std::string dwarfName = dwarfToString(dwarfToImpl(conf.dwarf), conf.device);
   auto dwarf = reg->find(dwarfName);
   assert(dwarf != nullptr);
 

--- a/bench.cpp
+++ b/bench.cpp
@@ -9,7 +9,7 @@
 
 namespace DwarfBench {
 
-std::string dwarfToString(Dwarf dwarf) {
+std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf) {
   switch (dwarf) {
   case ConstantExampleDPCPP: {
     return "ConstantExampleDPCPP";
@@ -62,7 +62,7 @@ std::vector<Measurement> DwarfBench::makeMeasurements(const RunConfig &conf) {
 
   GroupByRunOptions opts = GroupByRunOptions(_opts, 20, 1024); // TODO
 
-  std::string dwarfName = dwarfToString(conf.dwarf);
+  std::string dwarfName = dwarfToString(dwarfToImpl(conf.dwarf));
   auto dwarf = reg->find(dwarfName);
   assert(dwarf != nullptr);
 
@@ -85,6 +85,24 @@ std::vector<Measurement> DwarfBench::makeMeasurements(const RunConfig &conf) {
       });
 
   return ms;
+}
+
+DwarfBench::DwarfImpl DwarfBench::dwarfToImpl(Dwarf dwarf) {
+  switch (dwarf) {
+  case Dwarf::Sort:
+    return DwarfImpl::Radix;
+
+  case Dwarf::Join:
+    return DwarfImpl::Join;
+
+  case Dwarf::GroupBy:
+    return DwarfImpl::GroupBy;
+
+  case Dwarf::Scan:
+    return DwarfImpl::DPLScan;
+  }
+
+  assert(false);  // unreachable
 }
 
 DwarfBenchException::DwarfBenchException(const std::string &message)

--- a/bench.cpp
+++ b/bench.cpp
@@ -30,7 +30,7 @@ std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf) {
     return "HashBuildNonBitmask";
   }
   case Join: {
-    return "Join";
+    return "JoinOmnisci";
   }
   case NestedLoopJoin: {
     return "NestedLoopJoin";
@@ -93,7 +93,7 @@ DwarfBench::DwarfImpl DwarfBench::dwarfToImpl(Dwarf dwarf) {
     return DwarfImpl::Radix;
 
   case Dwarf::Join:
-    return DwarfImpl::Join;
+    return DwarfImpl::JoinOmnisci;
 
   case Dwarf::GroupBy:
     return DwarfImpl::GroupBy;

--- a/bench.cpp
+++ b/bench.cpp
@@ -30,6 +30,9 @@ std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf) {
     return "HashBuildNonBitmask";
   }
   case Join: {
+    return "Join";
+  }
+  case JoinOmnisci: {
     return "JoinOmnisci";
   }
   case NestedLoopJoin: {
@@ -61,7 +64,7 @@ std::vector<Measurement> DwarfBench::makeMeasurements(const RunConfig &conf) {
                                 .report_path = ""};
 
   GroupByRunOptions opts = GroupByRunOptions(_opts, 20, 1024); // TODO
-
+  
   std::string dwarfName = dwarfToString(dwarfToImpl(conf.dwarf));
   auto dwarf = reg->find(dwarfName);
   assert(dwarf != nullptr);

--- a/bench.cpp
+++ b/bench.cpp
@@ -64,7 +64,7 @@ std::vector<Measurement> DwarfBench::makeMeasurements(const RunConfig &conf) {
                                 .report_path = ""};
 
   GroupByRunOptions opts = GroupByRunOptions(_opts, 20, 1024); // TODO
-  
+
   std::string dwarfName = dwarfToString(dwarfToImpl(conf.dwarf));
   auto dwarf = reg->find(dwarfName);
   assert(dwarf != nullptr);
@@ -105,7 +105,7 @@ DwarfBench::DwarfImpl DwarfBench::dwarfToImpl(Dwarf dwarf) {
     return DwarfImpl::DPLScan;
   }
 
-  assert(false);  // unreachable
+  assert(false); // unreachable
 }
 
 DwarfBenchException::DwarfBenchException(const std::string &message)

--- a/bench.cpp
+++ b/bench.cpp
@@ -9,10 +9,12 @@
 
 namespace DwarfBench {
 
-std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf, DeviceType device) {
+std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf,
+                                      DeviceType device) {
   switch (dwarf) {
   case ConstantExampleDPCPP: {
-    return device == DeviceType::CPU ? "ConstantExampleDPCPP" : "ConstantExampleDPCPPCuda";
+    return device == DeviceType::CPU ? "ConstantExampleDPCPP"
+                                     : "ConstantExampleDPCPPCuda";
   }
   case DPLScan: {
     return device == DeviceType::CPU ? "DPLScan" : "DPLScanCuda";
@@ -21,33 +23,39 @@ std::string DwarfBench::dwarfToString(DwarfBench::DwarfImpl dwarf, DeviceType de
     return device == DeviceType::CPU ? "GroupBy" : "GroupByCuda";
   }
   case GroupByLocal: {
-    assert(device != DeviceType::GPU && "Calling unsupported GroupByLocal for GPU execution dwarf");
+    assert(device != DeviceType::GPU &&
+           "Calling unsupported GroupByLocal for GPU execution dwarf");
     return "GroupByLocal";
   }
   case HashBuild: {
-    assert(device != DeviceType::GPU && "Calling unsupported HashBuild for GPU execution dwarf");
+    assert(device != DeviceType::GPU &&
+           "Calling unsupported HashBuild for GPU execution dwarf");
     return "HashBuild";
   }
   case HashBuildNonBitmask: {
-    assert(device != DeviceType::GPU && "Calling unsupported HashBuildNonBitmask for GPU execution dwarf");
+    assert(device != DeviceType::GPU &&
+           "Calling unsupported HashBuildNonBitmask for GPU execution dwarf");
     return "HashBuildNonBitmask";
   }
   case Join: {
-    assert(device != DeviceType::GPU && "Calling unsupported Join for GPU execution dwarf");
+    assert(device != DeviceType::GPU &&
+           "Calling unsupported Join for GPU execution dwarf");
     return "Join";
   }
   case JoinOmnisci: {
     return device == DeviceType::CPU ? "JoinOmnisci" : "JoinOmnisciCuda";
   }
   case NestedLoopJoin: {
-    assert(device != DeviceType::GPU && "Calling unsupported NestedLoopJoin for GPU execution dwarf");
+    assert(device != DeviceType::GPU &&
+           "Calling unsupported NestedLoopJoin for GPU execution dwarf");
     return "NestedLoopJoin";
   }
   case Radix: {
     return device == DeviceType::CPU ? "Radix" : "RadixCuda";
   }
   case TBBSort: {
-    assert(device != DeviceType::GPU && "Calling unsupported TBBSort for GPU execution dwarf");
+    assert(device != DeviceType::GPU &&
+           "Calling unsupported TBBSort for GPU execution dwarf");
     return "TBBSort";
   }
   default: {

--- a/bench.hpp
+++ b/bench.hpp
@@ -79,6 +79,7 @@ private:
     NestedLoopJoin,
     Radix,
     TBBSort,
+    JoinOmnisci
   };
 
   DwarfImpl dwarfToImpl(Dwarf dwarf);

--- a/bench.hpp
+++ b/bench.hpp
@@ -11,16 +11,10 @@ namespace DwarfBench {
  *
  */
 enum Dwarf {
-  ConstantExampleDPCPP,
-  DPLScan,
-  GroupBy,
-  GroupByLocal,
-  HashBuild,
-  HashBuildNonBitmask,
+  Scan,
   Join,
-  NestedLoopJoin,
-  Radix,
-  TBBSort,
+  GroupBy,
+  Sort,
 };
 
 /**
@@ -72,6 +66,23 @@ public:
    * corresponds to a single run.
    */
   std::vector<Measurement> makeMeasurements(const RunConfig &conf);
+
+private:
+  enum DwarfImpl {
+    ConstantExampleDPCPP,
+    DPLScan,
+    GroupBy,
+    GroupByLocal,
+    HashBuild,
+    HashBuildNonBitmask,
+    Join,
+    NestedLoopJoin,
+    Radix,
+    TBBSort,
+  };
+
+  DwarfImpl dwarfToImpl(Dwarf dwarf);
+  std::string dwarfToString(DwarfImpl dwarf);
 };
 
 class DwarfBenchException : public std::exception {

--- a/bench.hpp
+++ b/bench.hpp
@@ -83,7 +83,7 @@ private:
   };
 
   DwarfImpl dwarfToImpl(Dwarf dwarf);
-  std::string dwarfToString(DwarfImpl dwarf);
+  std::string dwarfToString(DwarfImpl dwarf, DeviceType device);
 };
 
 class DwarfBenchException : public std::exception {

--- a/common/dpcpp/dpl_wrapper/dpl_wrapper.hpp
+++ b/common/dpcpp/dpl_wrapper/dpl_wrapper.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/iterator>
+#include <oneapi/dpl/numeric>
+
+#include <CL/sycl.hpp>
+
+#ifdef CUDA_COMPILATION
+#define SUFFIX(name) name##Cuda
+#else
+#define SUFFIX(name) name
+#endif
+
+namespace DPLWrapper {
+
+enum Device {
+    CPU,
+    CUDA
+};
+
+template <Device d, class Kernel, typename T>
+void exclusive_scan(sycl::queue &q, sycl::buffer<T> &src, sycl::buffer<T> &dst, T init_value) {
+    auto policy = oneapi::dpl::execution::make_device_policy<Kernel>(q);
+    oneapi::dpl::exclusive_scan(policy, oneapi::dpl::begin(src),
+                                oneapi::dpl::end(src),
+                                oneapi::dpl::begin(dst), init_value);
+}
+
+template <Device d, class Kernel, typename T, typename F>
+void copy_if(cl::sycl::device_selector &sel, sycl::buffer<T> &src, sycl::buffer<T> &dst, F func) {
+    auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
+    std::copy_if(
+        policy, oneapi::dpl::begin(src), oneapi::dpl::end(src),
+        oneapi::dpl::begin(dst), func);
+}
+
+template <Device d, class Kernel, typename T>
+void sort(cl::sycl::device_selector &sel, sycl::buffer<T> &src) {
+    auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
+    std::sort(policy, oneapi::dpl::begin(src), oneapi::dpl::end(src));
+}
+
+} //namespace DPLWrapper

--- a/common/dpcpp/dpl_wrapper/dpl_wrapper.hpp
+++ b/common/dpcpp/dpl_wrapper/dpl_wrapper.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
 #include <oneapi/dpl/iterator>
 #include <oneapi/dpl/numeric>
 
@@ -16,25 +16,26 @@
 namespace DPLWrapper {
 
 template <class Kernel, typename T>
-void exclusive_scan(sycl::queue &q, sycl::buffer<T> &src, sycl::buffer<T> &dst, T init_value) {
-    auto policy = oneapi::dpl::execution::make_device_policy<Kernel>(q);
-    oneapi::dpl::exclusive_scan(policy, oneapi::dpl::begin(src),
-                                oneapi::dpl::end(src),
-                                oneapi::dpl::begin(dst), init_value);
+void exclusive_scan(sycl::queue &q, sycl::buffer<T> &src, sycl::buffer<T> &dst,
+                    T init_value) {
+  auto policy = oneapi::dpl::execution::make_device_policy<Kernel>(q);
+  oneapi::dpl::exclusive_scan(policy, oneapi::dpl::begin(src),
+                              oneapi::dpl::end(src), oneapi::dpl::begin(dst),
+                              init_value);
 }
 
 template <class Kernel, typename T, typename F>
-void copy_if(cl::sycl::device_selector &sel, sycl::buffer<T> &src, sycl::buffer<T> &dst, F func) {
-    auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
-    std::copy_if(
-        policy, oneapi::dpl::begin(src), oneapi::dpl::end(src),
-        oneapi::dpl::begin(dst), func);
+void copy_if(cl::sycl::device_selector &sel, sycl::buffer<T> &src,
+             sycl::buffer<T> &dst, F func) {
+  auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
+  std::copy_if(policy, oneapi::dpl::begin(src), oneapi::dpl::end(src),
+               oneapi::dpl::begin(dst), func);
 }
 
 template <class Kernel, typename T>
 void sort(cl::sycl::device_selector &sel, sycl::buffer<T> &src) {
-    auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
-    std::sort(policy, oneapi::dpl::begin(src), oneapi::dpl::end(src));
+  auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
+  std::sort(policy, oneapi::dpl::begin(src), oneapi::dpl::end(src));
 }
 
-} //namespace DPLWrapper
+} // namespace DPLWrapper

--- a/common/dpcpp/dpl_wrapper/dpl_wrapper.hpp
+++ b/common/dpcpp/dpl_wrapper/dpl_wrapper.hpp
@@ -15,12 +15,7 @@
 
 namespace DPLWrapper {
 
-enum Device {
-    CPU,
-    CUDA
-};
-
-template <Device d, class Kernel, typename T>
+template <class Kernel, typename T>
 void exclusive_scan(sycl::queue &q, sycl::buffer<T> &src, sycl::buffer<T> &dst, T init_value) {
     auto policy = oneapi::dpl::execution::make_device_policy<Kernel>(q);
     oneapi::dpl::exclusive_scan(policy, oneapi::dpl::begin(src),
@@ -28,7 +23,7 @@ void exclusive_scan(sycl::queue &q, sycl::buffer<T> &src, sycl::buffer<T> &dst, 
                                 oneapi::dpl::begin(dst), init_value);
 }
 
-template <Device d, class Kernel, typename T, typename F>
+template <class Kernel, typename T, typename F>
 void copy_if(cl::sycl::device_selector &sel, sycl::buffer<T> &src, sycl::buffer<T> &dst, F func) {
     auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
     std::copy_if(
@@ -36,7 +31,7 @@ void copy_if(cl::sycl::device_selector &sel, sycl::buffer<T> &src, sycl::buffer<
         oneapi::dpl::begin(dst), func);
 }
 
-template <Device d, class Kernel, typename T>
+template <class Kernel, typename T>
 void sort(cl::sycl::device_selector &sel, sycl::buffer<T> &src) {
     auto policy = oneapi::dpl::execution::device_policy<Kernel>{sel};
     std::sort(policy, oneapi::dpl::begin(src), oneapi::dpl::end(src));

--- a/common/dpcpp/omnisci_hashtable.hpp
+++ b/common/dpcpp/omnisci_hashtable.hpp
@@ -1,12 +1,13 @@
 #pragma once
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/iterator>
+#include <oneapi/dpl/numeric>
+
 #include "dpcpp_common.hpp"
 #include "hashfunctions.hpp"
 #include <iostream>
 #include <memory>
 #include <numeric>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
-#include <oneapi/dpl/numeric>
 
 template <typename T> struct JoinOneToMany {
   T vals;

--- a/common/dpcpp/omnisci_hashtable.hpp
+++ b/common/dpcpp/omnisci_hashtable.hpp
@@ -38,7 +38,8 @@ std::vector<size_t> get_from_device(sycl::global_ptr<size_t> p, size_t size,
 }
 
 namespace OmniSci {
-template <typename K, typename V, typename H, class ConstructorKernel> class HashTable {
+template <typename K, typename V, typename H, class ConstructorKernel>
+class HashTable {
 public:
   HashTable(const std::vector<K> &keys_vec, K empty_key, H hasher,
             size_t ht_size, size_t distinct_size, sycl::queue &q)
@@ -61,22 +62,22 @@ public:
        auto pos = position_buffer.get_access(cgh);
        auto id = id_buffer.get_access(cgh);
 
-       cgh.parallel_for<ConstructorKernel>(std::max(ht_size, keys_vec.size()), [=](auto i) {
-         if (i < loc_f.ht_size) {
-           ht[i] = loc_f.empty_key;
-           cnt[i] = 0;
-           pos[i] = 0;
-         }
+       cgh.parallel_for<ConstructorKernel>(std::max(ht_size, keys_vec.size()),
+                                           [=](auto i) {
+                                             if (i < loc_f.ht_size) {
+                                               ht[i] = loc_f.empty_key;
+                                               cnt[i] = 0;
+                                               pos[i] = 0;
+                                             }
 
-         if (i < loc_f.keys_size) {
-           id[i] = 0;
-         }
-       });
+                                             if (i < loc_f.keys_size) {
+                                               id[i] = 0;
+                                             }
+                                           });
      }).wait();
   }
 
-  template <class Kernel>
-  void build_table() {
+  template <class Kernel> void build_table() {
     q.submit([&](sycl::handler &cgh) {
        hash_table_pimpl loc_f = *f;
        auto ht = hash_table.get_access(cgh);
@@ -219,8 +220,7 @@ public:
   size_t get_buffer_size() { return f->ht_size * 3 + f->keys_size; }
 
 private:
-  template <class Kernel>
-  void build_count_buffer() {
+  template <class Kernel> void build_count_buffer() {
     q.submit([&](sycl::handler &cgh) {
        hash_table_pimpl loc_f = *f;
        auto ht = hash_table.get_access(cgh);
@@ -247,8 +247,7 @@ private:
      }).wait();
   }
 
-  template <class Kernel>
-  void build_pos_buffer() {
+  template <class Kernel> void build_pos_buffer() {
     auto policy = oneapi::dpl::execution::make_device_policy<Kernel>(q);
     oneapi::dpl::exclusive_scan(policy, oneapi::dpl::begin(count_buffer),
                                 oneapi::dpl::end(count_buffer),

--- a/example/bench_usage/main.cpp
+++ b/example/bench_usage/main.cpp
@@ -3,21 +3,18 @@
 
 int main() {
   std::vector<DwarfBench::DeviceType> devices = {
-    DwarfBench::DeviceType::CPU,
-    DwarfBench::DeviceType::GPU,
+      DwarfBench::DeviceType::CPU,
+      DwarfBench::DeviceType::GPU,
   };
 
   std::vector<DwarfBench::Dwarf> dwarfs = {
-    DwarfBench::Dwarf::Join,
-    DwarfBench::Dwarf::Sort,
-    DwarfBench::Dwarf::Scan,
-    DwarfBench::Dwarf::GroupBy
-  };
-  
+      DwarfBench::Dwarf::Join, DwarfBench::Dwarf::Sort, DwarfBench::Dwarf::Scan,
+      DwarfBench::Dwarf::GroupBy};
+
   DwarfBench::DwarfBench db;
 
-  for (DwarfBench::Dwarf dwarf: dwarfs) {
-    for (DwarfBench::DeviceType device: devices) {
+  for (DwarfBench::Dwarf dwarf : dwarfs) {
+    for (DwarfBench::DeviceType device : devices) {
       DwarfBench::RunConfig rc = {
           .device = device,
           .inputSize = 1024,
@@ -28,10 +25,9 @@ int main() {
       auto results = db.makeMeasurements(rc);
 
       for (auto &result : results) {
-        std::cout << dwarf << ' ' << device << " RESULT: " << result.dataSize << ' ' << result.microseconds
-                  << std::endl;
+        std::cout << dwarf << ' ' << device << " RESULT: " << result.dataSize
+                  << ' ' << result.microseconds << std::endl;
       }
     }
   }
-
 }

--- a/example/bench_usage/main.cpp
+++ b/example/bench_usage/main.cpp
@@ -2,19 +2,36 @@
 #include <iostream>
 
 int main() {
-  DwarfBench::DwarfBench db;
-
-  DwarfBench::RunConfig rc = {
-      .device = DwarfBench::DeviceType::CPU,
-      .inputSize = 1024,
-      .iterations = 10,
-      .dwarf = DwarfBench::Dwarf::TBBSort,
+  std::vector<DwarfBench::DeviceType> devices = {
+    DwarfBench::DeviceType::CPU,
+    DwarfBench::DeviceType::GPU,
   };
 
-  auto results = db.makeMeasurements(rc);
+  std::vector<DwarfBench::Dwarf> dwarfs = {
+    DwarfBench::Dwarf::Join,
+    DwarfBench::Dwarf::Sort,
+    DwarfBench::Dwarf::Scan,
+    DwarfBench::Dwarf::GroupBy
+  };
+  
+  DwarfBench::DwarfBench db;
 
-  for (auto &result : results) {
-    std::cout << "RESULT: " << result.dataSize << ' ' << result.microseconds
-              << std::endl;
+  for (DwarfBench::Dwarf dwarf: dwarfs) {
+    for (DwarfBench::DeviceType device: devices) {
+      DwarfBench::RunConfig rc = {
+          .device = device,
+          .inputSize = 1024,
+          .iterations = 10,
+          .dwarf = dwarf,
+      };
+
+      auto results = db.makeMeasurements(rc);
+
+      for (auto &result : results) {
+        std::cout << dwarf << ' ' << device << " RESULT: " << result.dataSize << ' ' << result.microseconds
+                  << std::endl;
+      }
+    }
   }
+
 }

--- a/groupby/groupby.cpp
+++ b/groupby/groupby.cpp
@@ -31,9 +31,11 @@ void GroupBy::_run(const size_t buf_size, Meter &meter) {
   const std::vector<uint32_t> host_src_keys =
       helpers::make_random<uint32_t>(buf_size, 0, groups_count - 1);
 
+#ifndef NDEBUG
   std::vector<uint32_t> expected =
       expected_GroupBy(host_src_keys, host_src_vals, groups_count,
                        [](uint32_t x, uint32_t y) { return x + y; });
+#endif
 
   auto sel = get_device_selector(opts);
   sycl::queue q{*sel};
@@ -97,10 +99,12 @@ void GroupBy::_run(const size_t buf_size, Meter &meter) {
     result->host_time = host_end - host_start;
     out_buf.get_access<sycl::access::mode::read>();
 
+#ifndef NDEBUG
     if (output != expected) {
       std::cerr << "Incorrect results" << std::endl;
       result->valid = false;
     }
+#endif
 
     DwarfParams params{{"buf_size", std::to_string(buf_size)}};
     meter.add_result(std::move(params), std::move(result));

--- a/groupby/groupby_cuda.cpp
+++ b/groupby/groupby_cuda.cpp
@@ -31,9 +31,11 @@ void GroupByCuda::_run(const size_t buf_size, Meter &meter) {
   const std::vector<uint32_t> host_src_keys =
       helpers::make_random<uint32_t>(buf_size, 0, groups_count - 1);
 
+#ifndef NDEBUG
   std::vector<uint32_t> expected =
       expected_GroupBy(host_src_keys, host_src_vals, groups_count,
                        [](uint32_t x, uint32_t y) { return x + y; });
+#endif
 
   auto sel = get_device_selector(opts);
   sycl::queue q{*sel};
@@ -97,10 +99,12 @@ void GroupByCuda::_run(const size_t buf_size, Meter &meter) {
     result->host_time = host_end - host_start;
     out_buf.get_access<sycl::access::mode::read>();
 
+#ifndef NDEBUG
     if (output != expected) {
       std::cerr << "Incorrect results" << std::endl;
       result->valid = false;
     }
+#endif
 
     DwarfParams params{{"buf_size", std::to_string(buf_size)}};
     meter.add_result(std::move(params), std::move(result));

--- a/join/CMakeLists.txt
+++ b/join/CMakeLists.txt
@@ -11,10 +11,10 @@ if(ENABLE_DPCPP)
         add_dpcpp_cuda_lib(join join.cpp)
     endif()
 
-    if(ENABLE_EXPERIMENTAL)
-        add_dpcpp_lib(omnisci_join join_omnisci.cpp)
-        target_link_libraries(omnisci_join PRIVATE join_helpers_lib)
-
+    add_dpcpp_lib(omnisci_join join_omnisci.cpp)
+    target_link_libraries(omnisci_join PRIVATE join_helpers_lib)
+    
+    if(ENABLE_EXPERIMENTAL) 
         add_dpcpp_lib(slab_join slab_join.cpp)
         target_link_libraries(slab_join PRIVATE join_helpers_lib)
     endif()

--- a/join/CMakeLists.txt
+++ b/join/CMakeLists.txt
@@ -13,6 +13,9 @@ if(ENABLE_DPCPP)
 
     add_dpcpp_lib(omnisci_join join_omnisci.cpp)
     target_link_libraries(omnisci_join PRIVATE join_helpers_lib)
+
+    add_dpcpp_cuda_lib(omnisci_join join_omnisci_cuda.cpp)
+    target_link_libraries(omnisci_join PRIVATE join_helpers_lib)
     
     if(ENABLE_EXPERIMENTAL) 
         add_dpcpp_lib(slab_join slab_join.cpp)

--- a/join/join_omnisci.cpp
+++ b/join/join_omnisci.cpp
@@ -61,7 +61,10 @@ void JoinOmnisci::_run(const size_t buf_size, Meter &meter) {
   sycl::queue q{*sel};
   std::cout << "Selected device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
+
+#ifndef NDEBUG
   auto expected = build_join_id_buffer(table_a_keys, table_b_keys);
+#endif
 
   const size_t ht_size = unique_keys * 2;
   SimpleHasher<uint32_t> hasher(ht_size);
@@ -91,10 +94,12 @@ void JoinOmnisci::_run(const size_t buf_size, Meter &meter) {
     result->build_time = build_end - host_start;
     result->probe_time = host_end - build_end;
 
+#ifndef NDEBUG
     if (!(are_equal(expected, res, q))) {
       std::cerr << "Incorrect results" << std::endl;
       result->valid = false;
     }
+#endif
 
     DwarfParams params{{"buf_size", std::to_string(buf_size)}};
     meter.add_result(std::move(params), std::move(result));

--- a/join/join_omnisci.cpp
+++ b/join/join_omnisci.cpp
@@ -68,13 +68,15 @@ void JoinOmnisci::_run(const size_t buf_size, Meter &meter) {
 
   for (unsigned it = 0; it < opts.iterations; ++it) {
     std::unique_ptr<HashJoinResult> result = std::make_unique<HashJoinResult>();
-    OmniSci::HashTable<uint32_t, uint32_t, SimpleHasher<uint32_t>, class JoinOmnisciTable> ht(
-        table_a_keys, std::numeric_limits<uint32_t>::max(), hasher, ht_size,
-        unique_keys, q);
+    OmniSci::HashTable<uint32_t, uint32_t, SimpleHasher<uint32_t>,
+                       class JoinOmnisciTable>
+        ht(table_a_keys, std::numeric_limits<uint32_t>::max(), hasher, ht_size,
+           unique_keys, q);
     auto host_start = std::chrono::steady_clock::now();
 
     ht.build_table<class JoinOmnisciBuildTable>();
-    ht.build_id_buffer<class JoinOmnisciBuildID, class JoinOmnisciBuildCnt, class JoinOmnisciBuildPos>();
+    ht.build_id_buffer<class JoinOmnisciBuildID, class JoinOmnisciBuildCnt,
+                       class JoinOmnisciBuildPos>();
 
     auto build_end = std::chrono::steady_clock::now();
 

--- a/join/join_omnisci.cpp
+++ b/join/join_omnisci.cpp
@@ -1,7 +1,8 @@
 
 #include "common/dpcpp/omnisci_hashtable.hpp"
-#include "join_omnisci.hpp"
+
 #include "join_helpers/join_helpers.hpp"
+#include "join_omnisci.hpp"
 #include <unordered_set>
 
 using JoinOneToManySet = JoinOneToMany<std::unordered_set<size_t>>;

--- a/join/join_omnisci.cpp
+++ b/join/join_omnisci.cpp
@@ -1,6 +1,6 @@
 
-#include "join_omnisci.hpp"
 #include "common/dpcpp/omnisci_hashtable.hpp"
+#include "join_omnisci.hpp"
 #include "join_helpers/join_helpers.hpp"
 #include <unordered_set>
 

--- a/join/join_omnisci.hpp
+++ b/join/join_omnisci.hpp
@@ -20,4 +20,3 @@ public:
 private:
   void _run(const size_t buffer_size, Meter &meter);
 };
-

--- a/join/join_omnisci.hpp
+++ b/join/join_omnisci.hpp
@@ -10,3 +10,14 @@ public:
 private:
   void _run(const size_t buffer_size, Meter &meter);
 };
+
+class JoinOmnisciCuda : public Dwarf {
+public:
+  JoinOmnisciCuda();
+  void run(const RunOptions &opts) override;
+  void init(const RunOptions &opts) override;
+
+private:
+  void _run(const size_t buffer_size, Meter &meter);
+};
+

--- a/join/join_omnisci_cuda.cpp
+++ b/join/join_omnisci_cuda.cpp
@@ -1,7 +1,7 @@
 #include "common/dpcpp/omnisci_hashtable.hpp"
 
-#include "join_omnisci.hpp"
 #include "join_helpers/join_helpers.hpp"
+#include "join_omnisci.hpp"
 #include <unordered_set>
 
 using JoinOneToManySet = JoinOneToMany<std::unordered_set<size_t>>;
@@ -46,7 +46,7 @@ bool are_equal(const std::vector<JoinOneToManySet> &expected,
 JoinOmnisciCuda::JoinOmnisciCuda() : Dwarf("JoinOmnisciCuda") {}
 using namespace join_helpers;
 void JoinOmnisciCuda::_run(const size_t buf_size, Meter &meter) {
-    std::cout << "CUDA" << std::endl;
+  std::cout << "CUDA" << std::endl;
   auto opts = meter.opts();
 
   constexpr uint32_t empty_element = std::numeric_limits<uint32_t>::max();
@@ -58,7 +58,7 @@ void JoinOmnisciCuda::_run(const size_t buf_size, Meter &meter) {
       helpers::make_random<uint32_t>(buf_size);
 
   auto sel = get_device_selector(opts);
-  sycl::queue q{ *sel };
+  sycl::queue q{*sel};
   std::cout << "Selected device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
   auto expected = build_join_id_buffer(table_a_keys, table_b_keys);
@@ -68,14 +68,17 @@ void JoinOmnisciCuda::_run(const size_t buf_size, Meter &meter) {
 
   for (unsigned it = 0; it < opts.iterations; ++it) {
     std::unique_ptr<HashJoinResult> result = std::make_unique<HashJoinResult>();
-    OmniSci::HashTable<uint32_t, uint32_t, SimpleHasher<uint32_t>, class JoinOmnisciCudaTable> ht(
-        table_a_keys, std::numeric_limits<uint32_t>::max(), hasher, ht_size,
-        unique_keys, q);
+    OmniSci::HashTable<uint32_t, uint32_t, SimpleHasher<uint32_t>,
+                       class JoinOmnisciCudaTable>
+        ht(table_a_keys, std::numeric_limits<uint32_t>::max(), hasher, ht_size,
+           unique_keys, q);
     auto host_start = std::chrono::steady_clock::now();
 
     ht.build_table<class JoinOmnisciCudaBuildTable>();
     std::cout << "built" << std::endl;
-    ht.build_id_buffer<class JoinOmnisciCudaBuildID, class JoinOmnisciCudaBuildCnt, class JoinOmnisciCudaBuildPos>();
+    ht.build_id_buffer<class JoinOmnisciCudaBuildID,
+                       class JoinOmnisciCudaBuildCnt,
+                       class JoinOmnisciCudaBuildPos>();
     std::cout << "id" << std::endl;
     auto build_end = std::chrono::steady_clock::now();
 

--- a/register_dwarfs.cpp
+++ b/register_dwarfs.cpp
@@ -50,7 +50,7 @@ void populate_registry() {
   registry->registerd(new DPLScanCuda());
   registry->registerd(new RadixCuda());
   registry->registerd(new JoinOmnisciCuda());
-  registry->registerd(new GroupByCuda()); 
+  registry->registerd(new GroupByCuda());
 #endif
 #endif
 }

--- a/register_dwarfs.cpp
+++ b/register_dwarfs.cpp
@@ -50,6 +50,7 @@ void populate_registry() {
   registry->registerd(new DPLScanCuda());
   registry->registerd(new RadixCuda());
   registry->registerd(new JoinOmnisciCuda());
+  registry->registerd(new GroupByCuda()); 
 #endif
 #endif
 }

--- a/register_dwarfs.cpp
+++ b/register_dwarfs.cpp
@@ -37,10 +37,10 @@ void populate_registry() {
   registry->registerd(new GroupByLocal());
   registry->registerd(new Join());
   registry->registerd(new HashBuildNonBitmask());
+  registry->registerd(new JoinOmnisci());
 #ifdef EXPERIMENTAL
   registry->registerd(new ReduceDPCPP());
   registry->registerd(new CuckooHashBuild());
-  registry->registerd(new JoinOmnisci());
   registry->registerd(new SlabHashBuild());
   registry->registerd(new SlabJoin());
   registry->registerd(new SlabProbe());

--- a/register_dwarfs.cpp
+++ b/register_dwarfs.cpp
@@ -49,6 +49,7 @@ void populate_registry() {
   registry->registerd(new ConstantExampleDPCPPCuda());
   registry->registerd(new DPLScanCuda());
   registry->registerd(new RadixCuda());
+  registry->registerd(new JoinOmnisciCuda());
 #endif
 #endif
 }

--- a/scan/dplscan.cpp
+++ b/scan/dplscan.cpp
@@ -24,8 +24,10 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
   const size_t buffer_size = buf_size;
   const std::vector<int> host_src = helpers::make_random<int>(buffer_size);
 
+#ifndef NDEBUG
   std::vector<int> expected =
       expected_out<int>(host_src, [](int x) { return x < 5; });
+#endif
 
   auto sel = get_device_selector(opts);
   sycl::queue q{*sel};
@@ -63,6 +65,7 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
     result->host_time = host_end - host_start;
     DwarfParams params{{"buf_size", std::to_string(buffer_size)}};
 
+#ifndef NDEBUG
     {
       sycl::host_accessor res(out_buf, sycl::read_only);
       if (!helpers::check_first(res, expected, expected.size())) {
@@ -70,6 +73,8 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
         result->valid = false;
       }
     }
+#endif  
+
     meter.add_result(std::move(params), std::move(result));
   }
 }

--- a/scan/dplscan.cpp
+++ b/scan/dplscan.cpp
@@ -73,7 +73,7 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
         result->valid = false;
       }
     }
-#endif  
+#endif
 
     meter.add_result(std::move(params), std::move(result));
   }

--- a/scan/dplscan.cpp
+++ b/scan/dplscan.cpp
@@ -38,7 +38,8 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
 
     auto host_start = std::chrono::steady_clock::now();
 
-    DPLWrapper::copy_if<class DPLScanKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
+    DPLWrapper::copy_if<class DPLScanKernel>(*sel, src_buf, out_buf,
+                                             [](auto &x) { return x < 5; });
 
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/scan/dplscan.cpp
+++ b/scan/dplscan.cpp
@@ -38,7 +38,7 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
 
     auto host_start = std::chrono::steady_clock::now();
 
-    DPLWrapper::copy_if<DPLWrapper::Device::CPU, class DPLScanKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
+    DPLWrapper::copy_if<class DPLScanKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
 
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/scan/dplscan.cpp
+++ b/scan/dplscan.cpp
@@ -1,6 +1,4 @@
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
+#include "common/dpcpp/dpl_wrapper/dpl_wrapper.hpp"
 
 #include "scan/scan.hpp"
 #include <functional>
@@ -34,18 +32,13 @@ void DPLScan::run_scan(const size_t buf_size, Meter &meter) {
   std::cout << "Selected device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-  auto dev_policy =
-      oneapi::dpl::execution::device_policy<class Dev_Policy_Kernel>{*sel};
-
   for (auto it = 0; it < opts.iterations; ++it) {
     sycl::buffer<int> src_buf(host_src.data(), sycl::range<1>{buf_size});
     sycl::buffer<int> out_buf{sycl::range<1>{buf_size}};
 
     auto host_start = std::chrono::steady_clock::now();
 
-    auto end_it = std::copy_if(
-        dev_policy, oneapi::dpl::begin(src_buf), oneapi::dpl::end(src_buf),
-        oneapi::dpl::begin(out_buf), [](auto &x) { return x < 5; });
+    DPLWrapper::copy_if<DPLWrapper::Device::CPU, class DPLScanKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
 
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/scan/dplscan_cuda.cpp
+++ b/scan/dplscan_cuda.cpp
@@ -38,7 +38,7 @@ void DPLScanCuda::run_scan(const size_t buf_size, Meter &meter) {
 
     auto host_start = std::chrono::steady_clock::now();
 
-    DPLWrapper::copy_if<DPLWrapper::Device::CUDA, class DPLScanCudaKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
+    DPLWrapper::copy_if<class DPLScanCudaKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
 
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/scan/dplscan_cuda.cpp
+++ b/scan/dplscan_cuda.cpp
@@ -74,7 +74,8 @@ void DPLScanCuda::run_scan(const size_t buf_size, Meter &meter) {
       }
     }
 #endif
-    
+
+    meter.add_result(std::move(params), std::move(result));
   }
 }
 

--- a/scan/dplscan_cuda.cpp
+++ b/scan/dplscan_cuda.cpp
@@ -24,8 +24,10 @@ void DPLScanCuda::run_scan(const size_t buf_size, Meter &meter) {
   const size_t buffer_size = buf_size;
   const std::vector<int> host_src = helpers::make_random<int>(buffer_size);
 
+#ifndef NDEBUG
   std::vector<int> expected =
       expected_out<int>(host_src, [](int x) { return x < 5; });
+#endif
 
   auto sel = get_device_selector(opts);
   sycl::queue q{*sel.get()};
@@ -63,6 +65,7 @@ void DPLScanCuda::run_scan(const size_t buf_size, Meter &meter) {
     result->host_time = host_end - host_start;
     DwarfParams params{{"buf_size", std::to_string(buffer_size)}};
 
+#ifndef NDEBUG
     {
       sycl::host_accessor res(out_buf, sycl::read_only);
       if (!helpers::check_first(res, expected, expected.size())) {
@@ -70,6 +73,8 @@ void DPLScanCuda::run_scan(const size_t buf_size, Meter &meter) {
         result->valid = false;
       }
     }
+#endif
+    
   }
 }
 

--- a/scan/dplscan_cuda.cpp
+++ b/scan/dplscan_cuda.cpp
@@ -38,7 +38,8 @@ void DPLScanCuda::run_scan(const size_t buf_size, Meter &meter) {
 
     auto host_start = std::chrono::steady_clock::now();
 
-    DPLWrapper::copy_if<class DPLScanCudaKernel>(*sel, src_buf, out_buf, [](auto &x) { return x < 5; });
+    DPLWrapper::copy_if<class DPLScanCudaKernel>(*sel, src_buf, out_buf,
+                                                 [](auto &x) { return x < 5; });
 
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/sort/radix.cpp
+++ b/sort/radix.cpp
@@ -1,6 +1,4 @@
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
+#include "common/dpcpp/dpl_wrapper/dpl_wrapper.hpp"
 
 #include "sort/radix.hpp"
 
@@ -26,13 +24,11 @@ void Radix::_run(const size_t buf_size, Meter &meter) {
   std::cout << "Selected device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-  auto dev_policy = oneapi::dpl::execution::device_policy{*sel};
-
   for (auto it = 0; it < opts.iterations; ++it) {
     sycl::buffer<int> src(host_src.data(), sycl::range<1>{buf_size});
 
     auto host_start = std::chrono::steady_clock::now();
-    std::sort(dev_policy, oneapi::dpl::begin(src), oneapi::dpl::end(src));
+    DPLWrapper::sort<DPLWrapper::Device::CPU, class RadixKernel>(*sel, src);
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(
                              host_end - host_start)

--- a/sort/radix.cpp
+++ b/sort/radix.cpp
@@ -28,7 +28,7 @@ void Radix::_run(const size_t buf_size, Meter &meter) {
     sycl::buffer<int> src(host_src.data(), sycl::range<1>{buf_size});
 
     auto host_start = std::chrono::steady_clock::now();
-    DPLWrapper::sort<DPLWrapper::Device::CPU, class RadixKernel>(*sel, src);
+    DPLWrapper::sort<class RadixKernel>(*sel, src);
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(
                              host_end - host_start)

--- a/sort/radix.cpp
+++ b/sort/radix.cpp
@@ -17,7 +17,10 @@ Radix::Radix() : Dwarf("Radix") {}
 void Radix::_run(const size_t buf_size, Meter &meter) {
   auto opts = meter.opts();
   const std::vector<int> host_src = helpers::make_random<int>(buf_size);
+
+#ifndef NDEBUG
   const std::vector<int> expected = expected_out(host_src);
+#endif
 
   auto sel = get_device_selector(opts);
   sycl::queue q{*sel};
@@ -51,6 +54,7 @@ void Radix::_run(const size_t buf_size, Meter &meter) {
     result->host_time = host_end - host_start;
     DwarfParams params{{"buf_size", std::to_string(buf_size)}};
 
+#ifndef NDEBUG
     {
       sycl::host_accessor res(src, sycl::read_only);
       if (!helpers::check_first(res, expected, expected.size())) {
@@ -58,6 +62,8 @@ void Radix::_run(const size_t buf_size, Meter &meter) {
         result->valid = false;
       }
     }
+#endif
+
     meter.add_result(std::move(params), std::move(result));
   }
 }

--- a/sort/radix_cuda.cpp
+++ b/sort/radix_cuda.cpp
@@ -64,6 +64,7 @@ void RadixCuda::_run(const size_t buf_size, Meter &meter) {
     }
 #endif
 
+    meter.add_result(std::move(params), std::move(result));
   }
 }
 

--- a/sort/radix_cuda.cpp
+++ b/sort/radix_cuda.cpp
@@ -1,6 +1,4 @@
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
+#include "common/dpcpp/dpl_wrapper/dpl_wrapper.hpp"
 
 #include "sort/radix.hpp"
 
@@ -26,13 +24,11 @@ void RadixCuda::_run(const size_t buf_size, Meter &meter) {
   std::cout << "Selected device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-  auto dev_policy = oneapi::dpl::execution::device_policy{*sel};
-
   for (auto it = 0; it < opts.iterations; ++it) {
     sycl::buffer<int> src(host_src.data(), sycl::range<1>{buf_size});
 
     auto host_start = std::chrono::steady_clock::now();
-    std::sort(dev_policy, oneapi::dpl::begin(src), oneapi::dpl::end(src));
+    DPLWrapper::sort<DPLWrapper::Device::CUDA, class RadixCudaKernel>(*sel, src);
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(
                              host_end - host_start)

--- a/sort/radix_cuda.cpp
+++ b/sort/radix_cuda.cpp
@@ -17,7 +17,10 @@ RadixCuda::RadixCuda() : Dwarf("RadixCuda") {}
 void RadixCuda::_run(const size_t buf_size, Meter &meter) {
   auto opts = meter.opts();
   const std::vector<int> host_src = helpers::make_random<int>(buf_size);
+
+#ifndef NDEBUG
   const std::vector<int> expected = expected_out(host_src);
+#endif
 
   auto sel = get_device_selector(opts);
   sycl::queue q{*sel};
@@ -51,6 +54,7 @@ void RadixCuda::_run(const size_t buf_size, Meter &meter) {
     result->host_time = host_end - host_start;
     DwarfParams params{{"buf_size", std::to_string(buf_size)}};
 
+#ifndef NDEBUG
     {
       sycl::host_accessor res(src, sycl::read_only);
       if (!helpers::check_first(res, expected, expected.size())) {
@@ -58,6 +62,8 @@ void RadixCuda::_run(const size_t buf_size, Meter &meter) {
         result->valid = false;
       }
     }
+#endif
+
   }
 }
 

--- a/sort/radix_cuda.cpp
+++ b/sort/radix_cuda.cpp
@@ -28,7 +28,7 @@ void RadixCuda::_run(const size_t buf_size, Meter &meter) {
     sycl::buffer<int> src(host_src.data(), sycl::range<1>{buf_size});
 
     auto host_start = std::chrono::steady_clock::now();
-    DPLWrapper::sort<DPLWrapper::Device::CUDA, class RadixCudaKernel>(*sel, src);
+    DPLWrapper::sort<class RadixCudaKernel>(*sel, src);
     auto host_end = std::chrono::steady_clock::now();
     auto host_exe_time = std::chrono::duration_cast<std::chrono::microseconds>(
                              host_end - host_start)


### PR DESCRIPTION
PR fixes #55 issue, which reproduced not only on `RadixCuda` dwarf. Here we use template parameters for kernels to divide symbols for GPU (CUDA) and CPU

Also PR contains public API fix (hide actual dwarfs) and move Join Omnisci from experimental ([here](https://stackoverflow.com/questions/67923287/how-to-resolve-no-member-named-task-in-namespace-tbb-error-when-using-oned) an explanation why we had compilation error) 